### PR TITLE
Add optional Mengel-2016 glaciers-and-ice-caps emulator

### DIFF
--- a/src/MimiBRICK.jl
+++ b/src/MimiBRICK.jl
@@ -171,13 +171,7 @@ function get_model(;ssprcp_scenario::String="ssp245", start_year::Int=1850, end_
     # :gsic path is left untouched.
     if glacier_model == :mengel
         Mimi.replace!(brick, :glaciers_small_icecaps => glaciers_mengel)
-        update_param!(brick, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
-        update_param!(brick, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
-        update_param!(brick, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
-        update_param!(brick, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
-        update_param!(brick, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
-        update_param!(brick, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
-        update_param!(brick, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+        _apply_mengel_defaults!(brick)
     end
 
     # Return BRICK model.

--- a/src/MimiBRICK.jl
+++ b/src/MimiBRICK.jl
@@ -7,6 +7,7 @@ using CSVFiles, DataFrames, Distributions, Mimi
 include(joinpath("components", "antarctic_icesheet_component.jl"))
 include(joinpath("components", "antarctic_ocean_component.jl"))
 include(joinpath("components", "glaciers_small_icecaps_component.jl"))
+include(joinpath("components", "glaciers_mengel_component.jl"))
 include(joinpath("components", "global_sea_level_component.jl"))
 include(joinpath("components", "greenland_icesheet_component.jl"))
 include(joinpath("components", "landwater_storage_component.jl"))
@@ -35,7 +36,9 @@ Function Arguments:
       start_year      = initial year of the simulation period
       end_year        = ending year of the simulation period
 """
-function get_model(;ssprcp_scenario::String="ssp245", start_year::Int=1850, end_year::Int=2020)
+function get_model(;ssprcp_scenario::String="ssp245", start_year::Int=1850, end_year::Int=2020, glacier_model::Symbol = :gsic)
+
+    glacier_model in (:gsic, :mengel) || error("get_model: glacier_model must be :gsic or :mengel (got :$glacier_model)")
 
     #-----------------------#
     # ----- Load Data ----- #
@@ -160,6 +163,22 @@ function get_model(;ssprcp_scenario::String="ssp245", start_year::Int=1850, end_
 
     connect_param!(brick, :antarctic_icesheet => :antarctic_ocean_temperature, :antarctic_ocean  => :anto_temperature)
     connect_param!(brick, :antarctic_icesheet => :global_sea_level,            :global_sea_level => :sea_level_rise)
+
+    # ----- Optional: swap in the Mengel-2016 glacier emulator -----
+    # See create_brick_doeclim for details. Both glacier models cover the SAME
+    # inventory (glaciers AND small ice caps); Mimi.replace! preserves the
+    # :glaciers_small_icecaps slot name and the name-matched I/O wiring. The default
+    # :gsic path is left untouched.
+    if glacier_model == :mengel
+        Mimi.replace!(brick, :glaciers_small_icecaps => glaciers_mengel)
+        update_param!(brick, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
+        update_param!(brick, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
+        update_param!(brick, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
+        update_param!(brick, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
+        update_param!(brick, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
+        update_param!(brick, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
+        update_param!(brick, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+    end
 
     # Return BRICK model.
     return brick

--- a/src/components/glaciers_mengel_component.jl
+++ b/src/components/glaciers_mengel_component.jl
@@ -45,6 +45,18 @@ using Mimi
 # update_param! for calibrated runs rather than relying on these as a tuned central.
 const MENGEL_GLACIER_DEFAULTS = (a=0.45, b=0.52, T_lia=-0.45, f=0.5, tau_fast=40.0, tau_slow=250.0, sl0=0.0)
 
+# Internal helper: set all Mengel glacier parameters on model `m` (post-replace!).
+# Called by every constructor that supports glacier_model=:mengel to avoid triplication.
+function _apply_mengel_defaults!(m)
+    update_param!(m, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
+    update_param!(m, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
+    update_param!(m, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
+    update_param!(m, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
+    update_param!(m, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
+    update_param!(m, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
+    update_param!(m, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+end
+
 @defcomp glaciers_mengel begin
 
     # --------------------

--- a/src/components/glaciers_mengel_component.jl
+++ b/src/components/glaciers_mengel_component.jl
@@ -1,0 +1,95 @@
+using Mimi
+
+# ============================================================================
+# glaciers_mengel_component.jl
+#
+# Temperature-dependent-equilibrium glaciers-and-ice-caps (GIC) module, ported from
+# Mengel et al. 2016 (PNAS 113:2597; github.com/matthiasmengel/sealevel,
+# contributor_functions.py). This covers the SAME inventory as the component it
+# replaces -- mountain glaciers AND small/peripheral ice caps (the ice sheets are
+# handled separately by the Greenland and Antarctic components) -- so swapping it in
+# does not drop any mass. It is an optional drop-in alternative to BRICK's default
+# single-reservoir Wigley-Raper-Bakker `glaciers_small_icecaps` component, fixing its
+# commit-everything pathology (any sustained T > teq melts the WHOLE reservoir).
+#
+#   equilibrium:  S_eq(T) = a * (1 - exp(-b*(T - T_lia)))   (0 at T = T_lia; -> a)
+#   TWO-TIMESCALE transient (a single tau cannot be fast-early + slow-modern):
+#     dS_fast/dt = (f*S_eq - S_fast)/tau_fast      (committed early melt, short tau)
+#     dS_slow/dt = ((1-f)*S_eq - S_slow)/tau_slow  (modern tracking, long tau)
+#     S = S_fast + S_slow
+#
+# T = BRICK's global_surface_temperature (GMT anomaly rel 1850-1900, K = degC).
+# The emulator is driven by TOTAL temperature (anthropogenic + natural forcing
+# -- they are NOT, and cannot be, disentangled, since the model sees one
+# temperature).
+#
+# `gic_T_lia` = the glacier EQUILIBRIUM temperature ~ the Little-Ice-Age climate
+# (negative, rel 1850-1900). It makes glaciers OUT of equilibrium at the
+# 1850-1900 baseline (S_eq(0) = a(1 - exp(b*T_lia)) > 0), so they are COMMITTED
+# to melt by post-LIA warming that predates the forcing window -- this SIMULATES
+# the committed/disequilibrium early-20th-c melt directly (no external "natural"
+# budget, no forcing split). It is the physical generalization of the
+# single-reservoir `gsic_teq`.
+#
+# A sustained warming T* commits only S_eq(T*) < a -- a temperature-appropriate
+# remnant survives (NO full depletion). The output variable `gsic_sea_level` is
+# named identically to the default component so it wires into `global_sea_level`
+# unchanged. Mengel published coeffs (19 glacier-model fits, median a ~ 0.47 m,
+# b ~ 0.52 /K).
+# ============================================================================
+
+# Default Mengel glacier-emulator parameters for the BRICK constructors (used only
+# when glacier_model = :mengel). Fixed starting-point values from the MimiBRICK-FM
+# workflow, close to the Mengel-2016 19-glacier-model median (a ~ 0.47 m, b ~ 0.52
+# /K). The FM workflow calibrates these per posterior draw, so override them via
+# update_param! for calibrated runs rather than relying on these as a tuned central.
+const MENGEL_GLACIER_DEFAULTS = (a=0.45, b=0.52, T_lia=-0.45, f=0.5, tau_fast=40.0, tau_slow=250.0, sl0=0.0)
+
+@defcomp glaciers_mengel begin
+
+    # --------------------
+    # Model Parameters
+    # --------------------
+
+    gic_a        = Parameter()             # Asymptotic max contribution from the LIA state (m SLE).
+    gic_b        = Parameter()             # Temperature sensitivity (1/K).
+    gic_T_lia    = Parameter()             # Glacier equilibrium (LIA) temperature, rel 1850-1900 (°C, <0).
+    gic_f        = Parameter()             # Fast-mode fraction of the equilibrium (0-1).
+    gic_tau_fast = Parameter()             # Fast (committed) response timescale (yr).
+    gic_tau_slow = Parameter()             # Slow (modern) response timescale (yr).
+    gic_sl0      = Parameter()             # Initial cumulative sea level contribution at the start year (m).
+    global_surface_temperature = Parameter(index=[time]) # Global mean surface temperature anomaly relative to pre-industrial (°C).
+
+    # --------------------
+    # Model Variables
+    # --------------------
+
+    gsic_fast      = Variable(index=[time])   # Fast-mode (committed) sea level contribution (m).
+    gsic_slow      = Variable(index=[time])   # Slow-mode (modern-tracking) sea level contribution (m).
+    gsic_sea_level = Variable(index=[time])   # Cumulative sea level rise from glaciers and small ice caps (m).
+
+    # --------------------
+    # Model Equations
+    # --------------------
+
+    function run_timestep(p, v, d, t)
+
+        if is_first(t)
+
+            # Split the initial sea level contribution between the two reservoirs.
+            v.gsic_fast[t]      = p.gic_f * p.gic_sl0
+            v.gsic_slow[t]      = (1 - p.gic_f) * p.gic_sl0
+            v.gsic_sea_level[t] = p.gic_sl0
+
+        else
+
+            # Temperature-dependent equilibrium contribution (Mengel et al. 2016).
+            S_eq = p.gic_a * (1 - exp(-p.gic_b * (p.global_surface_temperature[t-1] - p.gic_T_lia)))
+
+            # Two-timescale relaxation toward the (partitioned) equilibrium.
+            v.gsic_fast[t] = v.gsic_fast[t-1] + (p.gic_f * S_eq       - v.gsic_fast[t-1]) / p.gic_tau_fast
+            v.gsic_slow[t] = v.gsic_slow[t-1] + ((1 - p.gic_f) * S_eq - v.gsic_slow[t-1]) / p.gic_tau_slow
+            v.gsic_sea_level[t] = v.gsic_fast[t] + v.gsic_slow[t]
+        end
+    end
+end

--- a/src/components/glaciers_mengel_component.jl
+++ b/src/components/glaciers_mengel_component.jl
@@ -9,27 +9,22 @@ using Mimi
 # replaces -- mountain glaciers AND small/peripheral ice caps (the ice sheets are
 # handled separately by the Greenland and Antarctic components) -- so swapping it in
 # does not drop any mass. It is an optional drop-in alternative to BRICK's default
-# single-reservoir Wigley-Raper-Bakker `glaciers_small_icecaps` component, fixing its
-# commit-everything pathology (any sustained T > teq melts the WHOLE reservoir).
+# single-reservoir Wigley-Raper-Bakker `glaciers_small_icecaps` component: a key 
+# improvement is that sustained T > teq no longer melts all GIC ice.
 #
 #   equilibrium:  S_eq(T) = a * (1 - exp(-b*(T - T_lia)))   (0 at T = T_lia; -> a)
-#   TWO-TIMESCALE transient (a single tau cannot be fast-early + slow-modern):
-#     dS_fast/dt = (f*S_eq - S_fast)/tau_fast      (committed early melt, short tau)
-#     dS_slow/dt = ((1-f)*S_eq - S_slow)/tau_slow  (modern tracking, long tau)
+#   TWO-TIMESCALE transient:
+#     dS_fast/dt = (f*S_eq - S_fast)/tau_fast      (small responsive glaciers, short tau)
+#     dS_slow/dt = ((1-f)*S_eq - S_slow)/tau_slow  (larger ice caps/high altitude glaciers, long tau)
 #     S = S_fast + S_slow
 #
 # T = BRICK's global_surface_temperature (GMT anomaly rel 1850-1900, K = degC).
-# The emulator is driven by TOTAL temperature (anthropogenic + natural forcing
-# -- they are NOT, and cannot be, disentangled, since the model sees one
-# temperature).
 #
 # `gic_T_lia` = the glacier EQUILIBRIUM temperature ~ the Little-Ice-Age climate
 # (negative, rel 1850-1900). It makes glaciers OUT of equilibrium at the
 # 1850-1900 baseline (S_eq(0) = a(1 - exp(b*T_lia)) > 0), so they are COMMITTED
-# to melt by post-LIA warming that predates the forcing window -- this SIMULATES
-# the committed/disequilibrium early-20th-c melt directly (no external "natural"
-# budget, no forcing split). It is the physical generalization of the
-# single-reservoir `gsic_teq`.
+# to melt by post-LIA warming that predates the forcing window -- this simulates
+# the committed/disequilibrium early-20th-c melt directly. 
 #
 # A sustained warming T* commits only S_eq(T*) < a -- a temperature-appropriate
 # remnant survives (NO full depletion). The output variable `gsic_sea_level` is
@@ -67,8 +62,8 @@ end
     gic_b        = Parameter()             # Temperature sensitivity (1/K).
     gic_T_lia    = Parameter()             # Glacier equilibrium (LIA) temperature, rel 1850-1900 (°C, <0).
     gic_f        = Parameter()             # Fast-mode fraction of the equilibrium (0-1).
-    gic_tau_fast = Parameter()             # Fast (committed) response timescale (yr).
-    gic_tau_slow = Parameter()             # Slow (modern) response timescale (yr).
+    gic_tau_fast = Parameter()             # Fast-response timescale (small, responsive glaciers) (yr).
+    gic_tau_slow = Parameter()             # Slow-response timescale (larger ice caps, high-altitude glaciers) (yr).
     gic_sl0      = Parameter()             # Initial cumulative sea level contribution at the start year (m).
     global_surface_temperature = Parameter(index=[time]) # Global mean surface temperature anomaly relative to pre-industrial (°C).
 
@@ -76,8 +71,8 @@ end
     # Model Variables
     # --------------------
 
-    gsic_fast      = Variable(index=[time])   # Fast-mode (committed) sea level contribution (m).
-    gsic_slow      = Variable(index=[time])   # Slow-mode (modern-tracking) sea level contribution (m).
+    gsic_fast      = Variable(index=[time])   # Fast-mode sea level contribution (small, responsive glaciers) (m).
+    gsic_slow      = Variable(index=[time])   # Slow-mode sea level contribution (larger/high-altitude glaciers) (m).
     gsic_sea_level = Variable(index=[time])   # Cumulative sea level rise from glaciers and small ice caps (m).
 
     # --------------------

--- a/src/create_models/BRICK_DOECLIM.jl
+++ b/src/create_models/BRICK_DOECLIM.jl
@@ -9,7 +9,7 @@ using MimiSNEASY
 # -------------------------------------------------------------------------------------------
 
 """
-    create_brick_doeclim(;ssprcp_scenario::String = "ssp245", start_year::Int=1850, end_year::Int=2020)
+    create_brick_doeclim(;ssprcp_scenario::String = "ssp245", start_year::Int=1850, end_year::Int=2020, glacier_model::Symbol = :gsic)
 
 Return a Mimi model instance with MimiBRICK and DOECLIM coupled together.
 
@@ -21,8 +21,14 @@ Function Arguments:
         ssprcp_scenario = SSP-RCP scenario for exogenous forcing
         start_year      = initial year of the simulation period
         end_year        = ending year of the simulation period
+        glacier_model   = glaciers & small ice caps model; `:gsic` (default) = the
+                          original single-reservoir Wigley-Raper-Bakker component,
+                          `:mengel` = the optional temperature-dependent-equilibrium
+                          Mengel-2016 emulator (same glaciers + small-ice-cap inventory)
 """
-function create_brick_doeclim(;ssprcp_scenario::String = "ssp245", start_year::Int=1850, end_year::Int=2020)
+function create_brick_doeclim(;ssprcp_scenario::String = "ssp245", start_year::Int=1850, end_year::Int=2020, glacier_model::Symbol = :gsic)
+
+    glacier_model in (:gsic, :mengel) || error("create_brick_doeclim: glacier_model must be :gsic or :mengel (got :$glacier_model)")
 
     #-----------------------#
     # ----- Load Data ----- #
@@ -180,6 +186,24 @@ function create_brick_doeclim(;ssprcp_scenario::String = "ssp245", start_year::I
 
     connect_param!(brick_doeclim, :antarctic_icesheet => :antarctic_ocean_temperature, :antarctic_ocean  => :anto_temperature)
     connect_param!(brick_doeclim, :antarctic_icesheet => :global_sea_level,            :global_sea_level => :sea_level_rise)
+
+    # ----- Optional: swap in the Mengel-2016 glacier emulator -----
+    # Replace the default single-reservoir glaciers & small ice caps component with
+    # the temperature-dependent-equilibrium Mengel-2016 emulator. Both represent the
+    # SAME inventory (glaciers AND small ice caps); Mimi.replace! keeps the
+    # :glaciers_small_icecaps slot name and reconnects the name-matched temperature
+    # input and gsic_sea_level output, so no other wiring changes. The default :gsic
+    # path is left untouched.
+    if glacier_model == :mengel
+        Mimi.replace!(brick_doeclim, :glaciers_small_icecaps => glaciers_mengel)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
+        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+    end
 
     # Return BRICK + DOEclim model.
     return brick_doeclim

--- a/src/create_models/BRICK_DOECLIM.jl
+++ b/src/create_models/BRICK_DOECLIM.jl
@@ -196,13 +196,7 @@ function create_brick_doeclim(;ssprcp_scenario::String = "ssp245", start_year::I
     # path is left untouched.
     if glacier_model == :mengel
         Mimi.replace!(brick_doeclim, :glaciers_small_icecaps => glaciers_mengel)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
-        update_param!(brick_doeclim, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+        _apply_mengel_defaults!(brick_doeclim)
     end
 
     # Return BRICK + DOEclim model.

--- a/src/create_models/SNEASY_BRICK.jl
+++ b/src/create_models/SNEASY_BRICK.jl
@@ -9,7 +9,7 @@ using MimiSNEASY
 # Function to run SNEASY-BRICK climate model over historic period.
 # ------------------------------------------------------------------------------
 """
-    create_sneasy_brick(;ssprcp_scenario::String = "ssp245", start_year::Int=1850, end_year::Int=2020)
+    create_sneasy_brick(;ssprcp_scenario::String = "ssp245", start_year::Int=1850, end_year::Int=2020, glacier_model::Symbol = :gsic)
 
 Return a Mimi model instance with MimiBRICK and MimiSNEASY coupled together.
 
@@ -21,8 +21,14 @@ Function Arguments:
         ssprcp_scenario = SSP-RCP scenario for exogenous forcing
         start_year      = initial year of the simulation period
         end_year        = ending year of the simulation period
+        glacier_model   = glaciers & small ice caps model; `:gsic` (default) = the
+                          original single-reservoir Wigley-Raper-Bakker component,
+                          `:mengel` = the optional temperature-dependent-equilibrium
+                          Mengel-2016 emulator (same glaciers + small-ice-cap inventory)
 """
-function create_sneasy_brick(; ssprcp_scenario::String="ssp245", start_year::Int=1850, end_year::Int=2020)
+function create_sneasy_brick(; ssprcp_scenario::String="ssp245", start_year::Int=1850, end_year::Int=2020, glacier_model::Symbol = :gsic)
+
+    glacier_model in (:gsic, :mengel) || error("create_sneasy_brick: glacier_model must be :gsic or :mengel (got :$glacier_model)")
 
  	# ---------------------------------------------
     # Load and clean up necessary data.
@@ -178,6 +184,22 @@ function create_sneasy_brick(; ssprcp_scenario::String="ssp245", start_year::Int
 
     connect_param!(m, :antarctic_icesheet => :antarctic_ocean_temperature, :antarctic_ocean  => :anto_temperature)
     connect_param!(m, :antarctic_icesheet => :global_sea_level,            :global_sea_level => :sea_level_rise)
+
+    # ----- Optional: swap in the Mengel-2016 glacier emulator -----
+    # See create_brick_doeclim for details. Both glacier models cover the SAME
+    # inventory (glaciers AND small ice caps); Mimi.replace! preserves the
+    # :glaciers_small_icecaps slot name and the name-matched I/O wiring, so only the
+    # glacier component itself changes. The default :gsic path is left untouched.
+    if glacier_model == :mengel
+        Mimi.replace!(m, :glaciers_small_icecaps => glaciers_mengel)
+        update_param!(m, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
+        update_param!(m, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
+        update_param!(m, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
+        update_param!(m, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
+        update_param!(m, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
+        update_param!(m, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
+        update_param!(m, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+    end
 
     # Return SNEASY-BRICK model.
     return m

--- a/src/create_models/SNEASY_BRICK.jl
+++ b/src/create_models/SNEASY_BRICK.jl
@@ -192,13 +192,7 @@ function create_sneasy_brick(; ssprcp_scenario::String="ssp245", start_year::Int
     # glacier component itself changes. The default :gsic path is left untouched.
     if glacier_model == :mengel
         Mimi.replace!(m, :glaciers_small_icecaps => glaciers_mengel)
-        update_param!(m, :glaciers_small_icecaps, :gic_a,        MENGEL_GLACIER_DEFAULTS.a)
-        update_param!(m, :glaciers_small_icecaps, :gic_b,        MENGEL_GLACIER_DEFAULTS.b)
-        update_param!(m, :glaciers_small_icecaps, :gic_T_lia,    MENGEL_GLACIER_DEFAULTS.T_lia)
-        update_param!(m, :glaciers_small_icecaps, :gic_f,        MENGEL_GLACIER_DEFAULTS.f)
-        update_param!(m, :glaciers_small_icecaps, :gic_tau_fast, MENGEL_GLACIER_DEFAULTS.tau_fast)
-        update_param!(m, :glaciers_small_icecaps, :gic_tau_slow, MENGEL_GLACIER_DEFAULTS.tau_slow)
-        update_param!(m, :glaciers_small_icecaps, :gic_sl0,      MENGEL_GLACIER_DEFAULTS.sl0)
+        _apply_mengel_defaults!(m)
     end
 
     # Return SNEASY-BRICK model.


### PR DESCRIPTION
## Summary

- Adds the **Mengel et al. 2016** (PNAS 113:2597) temperature-dependent-equilibrium glacier emulator as an optional drop-in replacement for the default `glaciers_small_icecaps` component, selectable via `glacier_model=:mengel` on `get_model`, `create_brick_doeclim`, and `create_sneasy_brick`.
- Implemented with `Mimi.replace!` into the existing `:glaciers_small_icecaps` slot — preserves the slot name and all name-matched I/O wiring; model bodies are untouched.
- Covers the **same inventory** as the component it replaces (mountain glaciers AND small/peripheral ice caps). Key improvement: a sustained warming T* commits only S_eq(T*) < a, so a temperature-appropriate remnant survives — the default component melts the entire reservoir for any sustained T > teq.
- Default `:gsic` path is **byte-identical** to upstream (`create_brick_doeclim() gsic_sea_level@2020 == 0.07635871278455457`).

## New files / changes

- `src/components/glaciers_mengel_component.jl` — new `@defcomp glaciers_mengel` with two-timescale relaxation (fast: small responsive glaciers, τ≈40 yr; slow: larger ice caps/high-altitude glaciers, τ≈250 yr), plus `const MENGEL_GLACIER_DEFAULTS` (starting-point parameter values close to Mengel 2016 19-glacier-model median; intended to be overridden via `update_param!` for calibrated runs).
- `src/MimiBRICK.jl`, `src/create_models/BRICK_DOECLIM.jl`, `src/create_models/SNEASY_BRICK.jl` — `glacier_model::Symbol` kwarg (default `:gsic`), input validation, and guarded `Mimi.replace!` block.

## Test plan

- [x] `create_brick_doeclim()` default `gsic_sea_level@2020 == 0.07635871278455457` (byte-identical to upstream)
- [x] `:mengel` path runs without error in all three constructors and produces a different value from `:gsic`
- [x] `glacier_model=:bad` throws a clear error in all three constructors

```julia
using MimiBRICK, Mimi
md = MimiBRICK.create_brick_doeclim(); run(md)
mm = MimiBRICK.create_brick_doeclim(glacier_model=:mengel); run(mm)
i = findfirst(==(2020), collect(Mimi.dim_keys(md, :time)))
@assert md[:glaciers_small_icecaps, :gsic_sea_level][i] == 0.07635871278455457
println("default OK; mengel=", mm[:glaciers_small_icecaps, :gsic_sea_level][i])
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)